### PR TITLE
Alternative config bool_to_env.

### DIFF
--- a/ecstest/config.py
+++ b/ecstest/config.py
@@ -2,16 +2,14 @@
 
 from os import environ as env
 
-def __env_to_bool(envname, default_value=False):
-    v = env.get(envname)
-    if v == '1':
-        return True
-    elif v == '0':
-        return False
-    elif v == None or v == '':
-        return default_value
-    else:
-        raise Exception("Unrecognized environment variable: %s=%s" % (envname,v))
+
+def _env_to_bool(envname, default_value=0):
+    envval = env.get(envname, default_value)
+    try:
+        return bool(int(envval))
+    except ValueError:
+        raise Exception("Unsupported env value: %s=%s" % (envname, envval))
+
 
 def get_config():
     """Return a dictionary of configuration values."""
@@ -24,14 +22,15 @@ def get_config():
             env.get('ECSTEST_CONTROL_ENDPOINT', 'https://127.0.0.1:4443'),
         'TOKEN_ENDPOINT':
             env.get('ECSTEST_TOKEN_ENDPOINT', 'https://127.0.0.1:4443/login'),
-        'VERIFY_SSL': __env_to_bool('ECSTEST_VERIFY_SSL', False),
+        'VERIFY_SSL': _env_to_bool('ECSTEST_VERIFY_SSL', 0),
         'REQUEST_TIMEOUT': float(env.get('ECSTEST_REQUEST_TIMEOUT', 15.0)),
-        'TOKEN_FILENAME': env.get('ECSTEST_TOKEN_FILENAME', '/tmp/ecstest.token'),
-        'CACHE_TOKEN': __env_to_bool('ECSTEST_CACHE_TOKEN', True),
-        'ACCESS_SSL': __env_to_bool('ECSTEST_ACCESS_SSL', False),
+        'TOKEN_FILENAME':
+            env.get('ECSTEST_TOKEN_FILENAME', '/tmp/ecstest.token'),
+        'CACHE_TOKEN': _env_to_bool('ECSTEST_CACHE_TOKEN', 1),
+        'ACCESS_SSL': _env_to_bool('ECSTEST_ACCESS_SSL', 0),
         'ACCESS_SERVER': env.get('ECSTEST_ACCESS_SERVER', 'localhost'),
         'ACCESS_PORT': int(env.get('ECSTEST_ACCESS_PORT', 3128)),
         'ACCESS_KEY': env.get('ECSTEST_ACCESS_KEY', 'mykey'),
         'ACCESS_SECRET': env.get('ECSTEST_ACCESS_SECRET', 'mysecret'),
-        'VERBOSE_OUTPUT': __env_to_bool('ECSTEST_VERBOSE_OUTPUT', False)
+        'VERBOSE_OUTPUT': _env_to_bool('ECSTEST_VERBOSE_OUTPUT', 0)
     }


### PR DESCRIPTION
Make this a little more "pythony" style.
Just attempt to convert var to bool, and reraise exception if fails.
Speciying the defaults as 0 or 1 might make it clear what the user is supposed to provide.

Only have single underscore for "private" methods. Double leading underscore is a convention reserved for:
https://www.python.org/dev/peps/pep-0008/
```
_double_leading_underscore : when naming a class attribute, invokes name mangling (inside class FooBar, __boo becomes _FooBar__boo ; see below).

__double_leading_and_trailing_underscore__ : "magic" objects or attributes that live in user-controlled namespaces. E.g. __init__ , __import__ or __file__ . Never invent such names; only use them as documented.
```